### PR TITLE
Fix order of decode

### DIFF
--- a/lib/activedirectory/protocol/netlogon.py
+++ b/lib/activedirectory/protocol/netlogon.py
@@ -59,8 +59,8 @@ class Decoder(object):
         netbios_domain = self._decode_rfc1035()
         netbios_hostname = self._decode_rfc1035()
         user = self._decode_rfc1035()
-        client_site = self._decode_rfc1035()
         server_site = self._decode_rfc1035()
+        client_site = self._decode_rfc1035()
         return Reply(type=type, flags=flags, domain_guid=domain_guid,
                      forest=forest, domain=domain, hostname=hostname,
                      netbios_domain=netbios_domain,
@@ -260,7 +260,7 @@ class Client(object):
                 if not self.m_queries:
                     break
                 try:
-                    data, addr = self.m_socket.recvfrom(self._bufsize,  
+                    data, addr = self.m_socket.recvfrom(self._bufsize,
                                                         socket.MSG_DONTWAIT)
                 except socket.error as err:
                     error = err.args[0]


### PR DESCRIPTION
Not being a specialist in netlogon/rfc1035, I've simply taken the order from: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/8401a33f-34a8-40ca-bf03-c3484b66265f

We're using:
DomainGuid (16 bytes)
DnsForestName (variable)
DnsDomainName (variable)
DnsHostName (variable)
NetbiosDomainName (variable)
NetbiosComputerName (variable)
UserName (variable)
DcSiteName (variable)
ClientSiteName (variable)